### PR TITLE
Allow Usage of authChannelWithCode($code) if LiveStreaming is disabled

### DIFF
--- a/src/AuthenticateService.php
+++ b/src/AuthenticateService.php
@@ -6,145 +6,138 @@ use alchemyguy\YoutubeLaravelApi\Auth\AuthService;
 use Carbon\Carbon;
 use Exception;
 
-class AuthenticateService extends AuthService {
+class AuthenticateService extends AuthService
+{
 
-	protected $googleLiveBroadcastSnippet;
-	protected $googleLiveBroadcastStatus;
-	protected $googleYoutubeLiveBroadcast;
+    protected $googleLiveBroadcastSnippet;
+    protected $googleLiveBroadcastStatus;
+    protected $googleYoutubeLiveBroadcast;
 
-	public function __construct() {
-		parent::__construct();
-		$this->googleLiveBroadcastSnippet = new \Google_Service_YouTube_LiveBroadcastSnippet;
-		$this->googleLiveBroadcastStatus = new \Google_Service_YouTube_LiveBroadcastStatus;
-		$this->googleYoutubeLiveBroadcast = new \Google_Service_YouTube_LiveBroadcast;
-	}
+    public function __construct()
+    {
+        parent::__construct();
+        $this->googleLiveBroadcastSnippet = new \Google_Service_YouTube_LiveBroadcastSnippet;
+        $this->googleLiveBroadcastStatus = new \Google_Service_YouTube_LiveBroadcastStatus;
+        $this->googleYoutubeLiveBroadcast = new \Google_Service_YouTube_LiveBroadcast;
+    }
 
-	public function authChannelWithCode($code) {
-		$authResponse = [];
+    public function authChannelWithCode($code)
+    {
+        $authResponse = [];
 
-		$token = $this->getToken($code);
-		if (!$token) {
-			$authResponse['error'] = 'invalid token';
-			return $authResponse;
-		}
-		$authResponse['token'] = $token;
-		$this->setAccessToken($authResponse['token']);
-		$authResponse['channel_details'] = $this->channelDetails();
-		$authResponse['live_streaming_status'] = $this->liveStreamTest($token) ? 'enabled' : 'disbaled';
+        $token = $this->getToken($code);
+        if (!$token) {
+            $authResponse['error'] = 'invalid token';
+            return $authResponse;
+        }
+        $authResponse['token'] = $token;
+        $this->setAccessToken($authResponse['token']);
+        $authResponse['channel_details'] = $this->channelDetails();
+        $authResponse['live_streaming_status'] = $this->liveStreamTest($token) ? 'enabled' : 'disbaled';
 
-		return $authResponse;
-	}
+        return $authResponse;
+    }
 
-	protected function channelDetails() {
-		$params = array('mine' => true);
-		$params = array_filter($params);
-		$part = 'snippet';
-		$service = new \Google_Service_YouTube($this->client);
-		return $service->channels->listChannels($part, $params);
-	}
+    protected function channelDetails()
+    {
+        $params = array('mine' => true);
+        $params = array_filter($params);
+        $part = 'snippet';
+        $service = new \Google_Service_YouTube($this->client);
+        return $service->channels->listChannels($part, $params);
+    }
 
-	protected function liveStreamTest($token) {
-		try {
-			$response = [];
-			/**
-			 * [setAccessToken [setting accent token to client]]
-			 */
-			$setAccessToken = $this->setAccessToken($token);
-			if (!$setAccessToken) {
-				return false;
-			}
+    protected function liveStreamTest($token)
+    {
+        try {
+            $response = [];
+            /**
+             * [setAccessToken [setting accent token to client]]
+             */
+            $setAccessToken = $this->setAccessToken($token);
+            if (!$setAccessToken) {
+                return false;
+            }
 
-			/**
-			 * [$service [instance of Google_Service_YouTube ]]
-			 * @var [type]
-			 */
-			$youtube = new \Google_Service_YouTube($this->client);
+            /**
+             * [$service [instance of Google_Service_YouTube ]]
+             * @var [type]
+             */
+            $youtube = new \Google_Service_YouTube($this->client);
 
-			$title = "test";
-			$description = "test live event";
-			$startdt = Carbon::now("Asia/Kolkata");
-			$startdtIso = $startdt->toIso8601String();
+            $title = "test";
+            $description = "test live event";
+            $startdt = Carbon::now("Asia/Kolkata");
+            $startdtIso = $startdt->toIso8601String();
 
-			$privacy_status = "public";
-			$language = 'English';
+            $privacy_status = "public";
+            $language = 'English';
 
-			/**
-			 * Create an object for the liveBroadcast resource [specify snippet's title, scheduled start time, and scheduled end time]
-			 */
-			$this->googleLiveBroadcastSnippet->setTitle($title);
-			$this->googleLiveBroadcastSnippet->setDescription($description);
-			$this->googleLiveBroadcastSnippet->setScheduledStartTime($startdtIso);
+            /**
+             * Create an object for the liveBroadcast resource [specify snippet's title, scheduled start time, and scheduled end time]
+             */
+            $this->googleLiveBroadcastSnippet->setTitle($title);
+            $this->googleLiveBroadcastSnippet->setDescription($description);
+            $this->googleLiveBroadcastSnippet->setScheduledStartTime($startdtIso);
 
-			/**
-			 * object for the liveBroadcast resource's status ["private, public or unlisted"]
-			 */
-			$this->googleLiveBroadcastStatus->setPrivacyStatus($privacy_status);
+            /**
+             * object for the liveBroadcast resource's status ["private, public or unlisted"]
+             */
+            $this->googleLiveBroadcastStatus->setPrivacyStatus($privacy_status);
 
-			/**
-			 * API Request [inserts the liveBroadcast resource]
-			 */
-			$this->googleYoutubeLiveBroadcast->setSnippet($this->googleLiveBroadcastSnippet);
-			$this->googleYoutubeLiveBroadcast->setStatus($this->googleLiveBroadcastStatus);
-			$this->googleYoutubeLiveBroadcast->setKind('youtube#liveBroadcast');
+            /**
+             * API Request [inserts the liveBroadcast resource]
+             */
+            $this->googleYoutubeLiveBroadcast->setSnippet($this->googleLiveBroadcastSnippet);
+            $this->googleYoutubeLiveBroadcast->setStatus($this->googleLiveBroadcastStatus);
+            $this->googleYoutubeLiveBroadcast->setKind('youtube#liveBroadcast');
 
-			/**
-			 * Execute Insert LiveBroadcast Resource Api [return an object that contains information about the new broadcast]
-			 */
-			$broadcastsResponse = $youtube->liveBroadcasts->insert('snippet,status', $this->googleYoutubeLiveBroadcast, array());
-			$response['broadcast_response'] = $broadcastsResponse;
-			$youtubeEventId = isset($broadcastsResponse['id']) ? $broadcastsResponse['id'] : false;
+            /**
+             * Execute Insert LiveBroadcast Resource Api [return an object that contains information about the new broadcast]
+             */
+            $broadcastsResponse = $youtube->liveBroadcasts->insert('snippet,status', $this->googleYoutubeLiveBroadcast, array());
+            $response['broadcast_response'] = $broadcastsResponse;
+            $youtubeEventId = isset($broadcastsResponse['id']) ? $broadcastsResponse['id'] : false;
 
-			if (!$youtubeEventId) {
-				return false;
-			}
+            if (!$youtubeEventId) {
+                return false;
+            }
 
-			$this->deleteEvent($youtubeEventId);
-			return true;
-
-		} catch (\Google_Service_Exception $e) {
-
+            $this->deleteEvent($youtubeEventId);
+            return true;
+        } catch (\Google_Service_Exception $e) {
             $errors = $e->getErrors();
             if (!empty($errors[0])) {
                 $error = $errors[0];
-                if (!empty($error["domain"]) && !empty($error["reason"]) && $error["domain"] == "youtube.liveBroadcast" && $error["reason"] == "livePermissionBlocked") {
+                if (!empty($error["domain"]) && !empty($error["reason"]) &&
+                    $error["domain"] == "youtube.liveBroadcast" && $error["reason"] == "livePermissionBlocked") {
                     return false;
                 }
             }
-			throw new Exception($e->getMessage(), 1);
+            throw new Exception($e->getMessage(), 1);
+        } catch (\Google_Exception $e) {
+            throw new Exception($e->getMessage(), 1);
+        } catch (Exception $e) {
+            throw new Exception($e->getMessage(), 1);
+        }
+    }
 
-		} catch (\Google_Exception $e) {
+    public function deleteEvent($youtubeEventId)
+    {
+        try {
 
-			throw new Exception($e->getMessage(), 1);
-
-		} catch (Exception $e) {
-
-			throw new Exception($e->getMessage(), 1);
-		}
-
-	}
-
-	public function deleteEvent($youtubeEventId) {
-		try {
-
-			/**
-			 * [$service [instance of Google_Service_YouTube]]
-			 */
-			$youtube = new \Google_Service_YouTube($this->client);
-			$deleteBroadcastsResponse = $youtube->liveBroadcasts->delete($youtubeEventId);
-			return true;
-
-		} catch (\Google_Service_Exception $e) {
-
-			throw new Exception($e->getMessage(), 1);
-
-		} catch (\Google_Exception $e) {
-
-			throw new Exception($e->getMessage(), 1);
-
-		} catch (Exception $e) {
-
-			throw new Exception($e->getMessage(), 1);
-		}
-	}
-
+            /**
+             * [$service [instance of Google_Service_YouTube]]
+             */
+            $youtube = new \Google_Service_YouTube($this->client);
+            $deleteBroadcastsResponse = $youtube->liveBroadcasts->delete($youtubeEventId);
+            return true;
+        } catch (\Google_Service_Exception $e) {
+            throw new Exception($e->getMessage(), 1);
+        } catch (\Google_Exception $e) {
+            throw new Exception($e->getMessage(), 1);
+        } catch (Exception $e) {
+            throw new Exception($e->getMessage(), 1);
+        }
+    }
 }

--- a/src/AuthenticateService.php
+++ b/src/AuthenticateService.php
@@ -103,6 +103,10 @@ class AuthenticateService extends AuthService {
 
 		} catch (\Google_Service_Exception $e) {
 
+            $error = $e->getErrors()[0] ?? [];
+            if ($error["domain"] ?? "" == "youtube.liveBroadcast" && $error["reason"] ?? "" == "livePermissionBlocked") {
+                return false;
+            }
 			throw new Exception($e->getMessage(), 1);
 
 		} catch (\Google_Exception $e) {

--- a/src/AuthenticateService.php
+++ b/src/AuthenticateService.php
@@ -103,9 +103,12 @@ class AuthenticateService extends AuthService {
 
 		} catch (\Google_Service_Exception $e) {
 
-            $error = $e->getErrors()[0] ?? [];
-            if ($error["domain"] ?? "" == "youtube.liveBroadcast" && $error["reason"] ?? "" == "livePermissionBlocked") {
-                return false;
+            $errors = $e->getErrors();
+            if (!empty($errors[0])) {
+                $error = $errors[0];
+                if (!empty($error["domain"]) && !empty($error["reason"]) && $error["domain"] == "youtube.liveBroadcast" && $error["reason"] == "livePermissionBlocked") {
+                    return false;
+                }
             }
 			throw new Exception($e->getMessage(), 1);
 


### PR DESCRIPTION
## Description

Checks if the `Google_Service_Exception` is thrown cause Live-Streaming is disabled
(The large commit is caused by Style fixes, the changes are in the lines 109 - 116)

## Motivation and context

fixes #17 

## How has this been tested?

Tested with Channels where Live-Streaming is disabled

* PHP 7.4
* Laravel 5.8
* Manjaro Linux 20.1

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply.

Please, please, please, don't send your pull request until all of the boxes are ticked. Once your pull request is created, it will trigger a build on our [continuous integration](http://www.phptherightway.com/#continuous-integration) server to make sure your [tests and code style pass](https://help.github.com/articles/about-required-status-checks/).

- [x] I have read the **[CONTRIBUTING](CONTRIBUTING.md)** document.
- [x] My pull request addresses exactly one patch/feature.
- [x] I have created a branch for this patch/feature.
- [x] Each individual commit in the pull request is meaningful.
- [ ] I have added tests to cover my changes.
- [x] If my change requires a change to the documentation, I have updated it accordingly.

If you're unsure about any of these, don't hesitate to ask. We're here to help!
